### PR TITLE
Fix session term loading in add-student page

### DIFF
--- a/update/.htaccess
+++ b/update/.htaccess
@@ -1,0 +1,3 @@
+RewriteEngine On
+RewriteCond %{REQUEST_URI} !login\.html$
+RewriteRule ^.*$ login.html [R=302,L]

--- a/update/app.js
+++ b/update/app.js
@@ -89,7 +89,7 @@ function getCookie(name) {
 }
 
 function deleteCookie(name) {
-    document.cookie = name + '=; Max-Age=-99999999;';
+    document.cookie = `${name}=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT;`;
 }
 
 function getHeaders() {

--- a/update/config.js
+++ b/update/config.js
@@ -1,1 +1,1 @@
-const backend_url = 'https://api.bmp.com.ng';
+const backend_url = 'http://127.0.0.1:8000';

--- a/update/config.js
+++ b/update/config.js
@@ -1,1 +1,1 @@
-const backend_url = 'http://127.0.0.1:8000';
+const backend_url = 'https://api.bmp.com.ng';

--- a/update/v14/js/add-student.js
+++ b/update/v14/js/add-student.js
@@ -29,7 +29,9 @@ document.addEventListener('DOMContentLoaded', function () {
     loadSessionsIntoSelect('session-id');
 
     // Handle dependent dropdowns with detailed debugging
-    document.getElementById('session-id').addEventListener('change', function() {
+    const sessionSelect = document.getElementById('session-id');
+
+    const handleSessionChange = function() {
         const sessionId = this.value;
         console.log('Session changed to:', sessionId);
         console.log('Selected session text:', this.options[this.selectedIndex]?.text);
@@ -38,7 +40,19 @@ document.addEventListener('DOMContentLoaded', function () {
         } else {
             clearSelect('term-id', 'Please Select Term *');
         }
-    });
+    };
+
+    if (sessionSelect) {
+        // Standard change event
+        sessionSelect.addEventListener('change', handleSessionChange);
+
+        // Ensure Select2 plugin triggers also load terms
+        if (typeof $ !== 'undefined' && $.fn && $.fn.select2) {
+            $(sessionSelect).on('select2:select', function () {
+                handleSessionChange.call(this);
+            });
+        }
+    }
 
     document.getElementById('class-id').addEventListener('change', function() {
         const classId = this.value;

--- a/update/v14/js/add-student.js
+++ b/update/v14/js/add-student.js
@@ -26,7 +26,13 @@ async function fetchSchoolId() {
         const response = await fetch(`${backend_url}/api/v1/user`, { headers: getHeaders() });
         if (response.ok) {
             const data = await response.json();
-            schoolId = data.school_id || data.data?.school_id || data.school?.id || null;
+            schoolId =
+                data.school_id ||
+                data.data?.school_id ||
+                data.data?.school?.id ||
+                data.school?.id ||
+                null;
+            console.log('Fetched school ID:', schoolId);
         } else {
             console.warn('Failed to fetch school ID', response.status);
         }
@@ -41,8 +47,8 @@ function formatDateToISO(dateStr) {
     return `${year}-${month}-${day}`;
 }
 
-document.addEventListener('DOMContentLoaded', function () {
-    fetchSchoolId();
+document.addEventListener('DOMContentLoaded', async function () {
+    await fetchSchoolId();
     const form = document.getElementById('add-student-form');
 
     // Load initial independent dropdowns
@@ -231,6 +237,11 @@ async function loadParentsIntoSelect(selectId) {
         if (response.ok) {
             const parents = await response.json();
 
+            if (!schoolId && parents.length > 0) {
+                schoolId = parents[0].school_id;
+                console.log('Derived school ID from parents:', schoolId);
+            }
+
             const select = document.getElementById(selectId);
             if (select) {
                 select.innerHTML = '<option value="">Please Select Parent *</option>';
@@ -282,6 +293,11 @@ async function loadSessionsIntoSelect(selectId) {
         
         if (response.ok) {
             const sessions = await response.json();
+
+            if (!schoolId && sessions.length > 0) {
+                schoolId = sessions[0].school_id;
+                console.log('Derived school ID from sessions:', schoolId);
+            }
 
             const select = document.getElementById(selectId);
             if (select) {

--- a/update/v14/js/add-student.js
+++ b/update/v14/js/add-student.js
@@ -32,6 +32,7 @@ document.addEventListener('DOMContentLoaded', function () {
     document.getElementById('session-id').addEventListener('change', function() {
         const sessionId = this.value;
         console.log('Session changed to:', sessionId);
+        console.log('Selected session text:', this.options[this.selectedIndex]?.text);
         if (sessionId) {
             loadSessionTermsIntoSelect(sessionId, 'term-id');
         } else {
@@ -290,10 +291,11 @@ async function loadSessionTermsIntoSelect(sessionId, selectId) {
             } else {
                 console.warn('Unknown terms structure');
             }
-
+            console.log('Parsed terms:', terms);
             select.innerHTML = '<option value="">Please Select Term *</option>';
             if (terms.length > 0) {
-                terms.forEach(term => {
+                terms.forEach((term, idx) => {
+                    console.log(`Term ${idx}:`, term);
                     const option = new Option(term.name, term.id);
                     select.add(option);
                 });

--- a/update/v14/js/add-student.js
+++ b/update/v14/js/add-student.js
@@ -13,7 +13,6 @@ function getCookie(name) {
 // Helper function to get headers
 function getHeaders() {
     const token = getCookie('token');
-    console.log('Token found:', token ? 'Yes' : 'No');
     return {
         'Authorization': `Bearer ${token}`,
         'Accept': 'application/json'
@@ -28,13 +27,11 @@ document.addEventListener('DOMContentLoaded', function () {
     loadClassesIntoSelect('class-id');
     loadSessionsIntoSelect('session-id');
 
-    // Handle dependent dropdowns with detailed debugging
+    // Handle dependent dropdowns
     const sessionSelect = document.getElementById('session-id');
 
     const handleSessionChange = function() {
         const sessionId = this.value;
-        console.log('Session changed to:', sessionId);
-        console.log('Selected session text:', this.options[this.selectedIndex]?.text);
         if (sessionId) {
             loadSessionTermsIntoSelect(sessionId, 'term-id');
         } else {
@@ -60,8 +57,6 @@ document.addEventListener('DOMContentLoaded', function () {
 
     const handleClassChange = function() {
         const classId = this.value;
-        console.log('Class changed to:', classId);
-        console.log('Selected class text:', this.options[this.selectedIndex]?.text);
 
         if (classId) {
             // Clear dependent dropdowns first
@@ -89,7 +84,6 @@ document.addEventListener('DOMContentLoaded', function () {
     const handleClassArmChange = function() {
         const classId = document.getElementById('class-id').value;
         const armId = this.value;
-        console.log('Class Arm changed to:', armId, 'for class:', classId);
 
         if (armId && classId) {
             clearSelect('class-section-id', 'Please Select Section');
@@ -111,8 +105,6 @@ document.addEventListener('DOMContentLoaded', function () {
 
     const handleClassSectionChange = function() {
         const sectionId = this.value;
-        console.log('Class Section changed to:', sectionId);
-        console.log('Selected section text:', this.options[this.selectedIndex]?.text);
     };
 
     if (classSectionSelect) {
@@ -197,29 +189,22 @@ function clearSelect(selectId, defaultText) {
     const select = document.getElementById(selectId);
     if (select) {
         select.innerHTML = `<option value="">${defaultText}</option>`;
-        console.log(`Cleared select: ${selectId}`);
-    } else {
-        console.error(`Select element not found: ${selectId}`);
     }
 }
 
 // Load parents into select
 async function loadParentsIntoSelect(selectId) {
-    console.log('Loading parents...');
     try {
         const url = `${backend_url}/api/v1/all-parents`;
-        console.log('Fetching parents from:', url);
         
         const response = await fetch(url, {
             headers: getHeaders()
         });
         
-        console.log('Parents response status:', response.status);
         
         if (response.ok) {
             const parents = await response.json();
-            console.log('Parents data:', parents);
-            
+
             const select = document.getElementById(selectId);
             if (select) {
                 select.innerHTML = '<option value="">Please Select Parent *</option>';
@@ -227,34 +212,25 @@ async function loadParentsIntoSelect(selectId) {
                     const option = new Option(`${parent.first_name} ${parent.last_name}`, parent.id);
                     select.add(option);
                 });
-                console.log(`Loaded ${parents.length} parents into ${selectId}`);
             }
-        } else {
-            const errorText = await response.text();
-            console.error('Failed to load parents:', response.status, errorText);
         }
     } catch (error) {
-        console.error('Error loading parents:', error);
     }
 }
 
 // Load classes into select
 async function loadClassesIntoSelect(selectId) {
-    console.log('Loading classes...');
     try {
         const url = `${backend_url}/api/v1/classes`;
-        console.log('Fetching classes from:', url);
         
         const response = await fetch(url, {
             headers: getHeaders()
         });
         
-        console.log('Classes response status:', response.status);
         
         if (response.ok) {
             const classes = await response.json();
-            console.log('Classes data:', classes);
-            
+
             const select = document.getElementById(selectId);
             if (select) {
                 select.innerHTML = '<option value="">Please Select Class *</option>';
@@ -262,34 +238,25 @@ async function loadClassesIntoSelect(selectId) {
                     const option = new Option(_class.name, _class.id);
                     select.add(option);
                 });
-                console.log(`Loaded ${classes.length} classes into ${selectId}`);
             }
-        } else {
-            const errorText = await response.text();
-            console.error('Failed to load classes:', response.status, errorText);
         }
     } catch (error) {
-        console.error('Error loading classes:', error);
     }
 }
 
 // Load sessions into select
 async function loadSessionsIntoSelect(selectId) {
-    console.log('Loading sessions...');
     try {
         const url = `${backend_url}/api/v1/sessions`;
-        console.log('Fetching sessions from:', url);
         
         const response = await fetch(url, {
             headers: getHeaders()
         });
         
-        console.log('Sessions response status:', response.status);
         
         if (response.ok) {
             const sessions = await response.json();
-            console.log('Sessions data:', sessions);
-            
+
             const select = document.getElementById(selectId);
             if (select) {
                 select.innerHTML = '<option value="">Please Select Session *</option>';
@@ -297,20 +264,14 @@ async function loadSessionsIntoSelect(selectId) {
                     const option = new Option(session.name, session.id);
                     select.add(option);
                 });
-                console.log(`Loaded ${sessions.length} sessions into ${selectId}`);
             }
-        } else {
-            const errorText = await response.text();
-            console.error('Failed to load sessions:', response.status, errorText);
         }
     } catch (error) {
-        console.error('Error loading sessions:', error);
     }
 }
 
 // Load session terms into select
 async function loadSessionTermsIntoSelect(sessionId, selectId) {
-    console.log('Loading terms for session:', sessionId);
 
     const select = document.getElementById(selectId);
     if (select) {
@@ -319,19 +280,16 @@ async function loadSessionTermsIntoSelect(sessionId, selectId) {
 
     try {
         const url = `${backend_url}/api/v1/sessions/${sessionId}/terms`;
-        console.log('Fetching terms from:', url);
 
         const response = await fetch(url, {
             headers: getHeaders()
         });
 
-        console.log('Terms response status:', response.status);
 
         if (!select) return;
 
         if (response.ok) {
             const data = await response.json();
-            console.log('Terms raw data:', data);
 
             let terms = [];
             if (Array.isArray(data)) {
@@ -342,41 +300,29 @@ async function loadSessionTermsIntoSelect(sessionId, selectId) {
                 terms = data.terms;
             } else if (Array.isArray(data.data?.terms)) {
                 terms = data.data.terms;
-            } else {
-                console.warn('Unknown terms structure');
             }
-            console.log('Parsed terms:', terms);
             select.innerHTML = '<option value="">Please Select Term *</option>';
             if (terms.length > 0) {
                 terms.forEach((term, idx) => {
-                    console.log(`Term ${idx}:`, term);
                     const option = new Option(term.name, term.id);
                     select.add(option);
                 });
-                console.log(`Loaded ${terms.length} terms into ${selectId}`);
             } else {
                 const option = new Option('No terms available', '');
                 select.add(option);
-                console.log('No terms found');
             }
         } else {
             select.innerHTML = '<option value="">No terms available</option>';
-            const errorText = await response.text();
-            console.error('Failed to load terms:', response.status, errorText);
         }
     } catch (error) {
         if (select) {
             select.innerHTML = '<option value="">Failed to load terms</option>';
         }
-        console.error('Error loading terms:', error);
     }
 }
 
-// Load class arms into select - WITH DETAILED DEBUGGING
+// Load class arms into select
 async function loadClassArmsIntoSelect(classId, selectId) {
-    console.log('=== LOADING CLASS ARMS ===');
-    console.log('Class ID:', classId);
-    console.log('Select ID:', selectId);
     
     // Show loading state
     const select = document.getElementById(selectId);
@@ -386,19 +332,14 @@ async function loadClassArmsIntoSelect(classId, selectId) {
     
     try {
         const url = `${backend_url}/api/v1/classes/${classId}/arms`;
-        console.log('Fetching class arms from:', url);
         
         const headers = getHeaders();
-        console.log('Request headers:', headers);
         
         const response = await fetch(url, { headers });
         
-        console.log('Class arms response status:', response.status);
-        console.log('Response headers:', Object.fromEntries(response.headers.entries()));
         
         if (response.ok) {
             const data = await response.json();
-            console.log('Class arms raw data:', data);
 
             let arms = [];
             if (Array.isArray(data)) {
@@ -409,49 +350,37 @@ async function loadClassArmsIntoSelect(classId, selectId) {
                 arms = data.arms;
             } else if (Array.isArray(data.data?.arms)) {
                 arms = data.data.arms;
-            } else {
-                console.warn('Unknown class arms structure');
             }
-            console.log('Parsed arms:', arms);
 
             if (select) {
                 select.innerHTML = '<option value="">Please Select Class Arm *</option>';
 
                 if (arms.length > 0) {
                     arms.forEach((arm, index) => {
-                        console.log(`Adding arm ${index}:`, arm);
                         const option = new Option(arm.name, arm.id);
                         select.add(option);
                     });
-                    console.log(`Successfully loaded ${arms.length} arms into ${selectId}`);
                 } else {
-                    console.warn('No arms found');
                     const noDataOption = new Option('No arms available', '');
                     select.add(noDataOption);
                 }
             }
         } else {
-            const errorText = await response.text();
-            console.error('Failed to load class arms:', response.status, errorText);
             
             if (select) {
                 select.innerHTML = '<option value="">Failed to load arms</option>';
             }
         }
     } catch (error) {
-        console.error('Error loading class arms:', error);
-        console.error('Error stack:', error.stack);
         
         if (select) {
             select.innerHTML = '<option value="">Error loading arms</option>';
         }
     }
-    console.log('=== END LOADING CLASS ARMS ===');
 }
 
 // Load class arm sections into select
 async function loadClassArmSectionsIntoSelect(classId, armId, selectId) {
-    console.log('Loading sections for class:', classId, 'arm:', armId);
     
     // Show loading state
     const select = document.getElementById(selectId);
@@ -461,17 +390,14 @@ async function loadClassArmSectionsIntoSelect(classId, armId, selectId) {
     
     try {
         const url = `${backend_url}/api/v1/classes/${classId}/arms/${armId}/sections`;
-        console.log('Fetching sections from:', url);
         
         const response = await fetch(url, {
             headers: getHeaders()
         });
         
-        console.log('Sections response status:', response.status);
         
         if (response.ok) {
             const data = await response.json();
-            console.log('Sections raw data:', data);
 
             let sections = [];
             if (Array.isArray(data)) {
@@ -482,10 +408,7 @@ async function loadClassArmSectionsIntoSelect(classId, armId, selectId) {
                 sections = data.sections;
             } else if (Array.isArray(data.data?.sections)) {
                 sections = data.data.sections;
-            } else {
-                console.warn('Unknown sections structure');
             }
-            console.log('Parsed sections:', sections);
 
             if (select) {
                 select.innerHTML = '<option value="">Please Select Section</option>';
@@ -495,23 +418,18 @@ async function loadClassArmSectionsIntoSelect(classId, armId, selectId) {
                         const option = new Option(section.name, section.id);
                         select.add(option);
                     });
-                    console.log(`Loaded ${sections.length} sections into ${selectId}`);
                 } else {
-                    console.warn('No sections found');
                     const noDataOption = new Option('No sections available', '');
                     select.add(noDataOption);
                 }
             }
         } else {
-            const errorText = await response.text();
-            console.error('Failed to load sections:', response.status, errorText);
             
             if (select) {
                 select.innerHTML = '<option value="">Failed to load sections</option>';
             }
         }
     } catch (error) {
-        console.error('Error loading sections:', error);
         
         if (select) {
             select.innerHTML = '<option value="">Error loading sections</option>';

--- a/update/v14/js/add-student.js
+++ b/update/v14/js/add-student.js
@@ -256,34 +256,45 @@ async function loadSessionsIntoSelect(selectId) {
 // Load session terms into select
 async function loadSessionTermsIntoSelect(sessionId, selectId) {
     console.log('Loading terms for session:', sessionId);
+
+    const select = document.getElementById(selectId);
+    if (select) {
+        select.innerHTML = '<option value="">Loading terms...</option>';
+    }
+
     try {
         const url = `${backend_url}/api/v1/sessions/${sessionId}/terms`;
         console.log('Fetching terms from:', url);
-        
+
         const response = await fetch(url, {
             headers: getHeaders()
         });
-        
+
         console.log('Terms response status:', response.status);
-        
+
+        if (!select) return;
+
         if (response.ok) {
-            const terms = await response.json();
-            console.log('Terms data:', terms);
-            
-            const select = document.getElementById(selectId);
-            if (select) {
-                select.innerHTML = '<option value="">Please Select Term *</option>';
-                terms.forEach(term => {
-                    const option = new Option(term.name, term.id);
-                    select.add(option);
-                });
-                console.log(`Loaded ${terms.length} terms into ${selectId}`);
-            }
+            const data = await response.json();
+            console.log('Terms data:', data);
+
+            const terms = Array.isArray(data) ? data : data.data || [];
+
+            select.innerHTML = '<option value="">Please Select Term *</option>';
+            terms.forEach(term => {
+                const option = new Option(term.name, term.id);
+                select.add(option);
+            });
+            console.log(`Loaded ${terms.length} terms into ${selectId}`);
         } else {
+            select.innerHTML = '<option value="">No terms available</option>';
             const errorText = await response.text();
             console.error('Failed to load terms:', response.status, errorText);
         }
     } catch (error) {
+        if (select) {
+            select.innerHTML = '<option value="">Failed to load terms</option>';
+        }
         console.error('Error loading terms:', error);
     }
 }

--- a/update/v14/js/add-student.js
+++ b/update/v14/js/add-student.js
@@ -27,7 +27,6 @@ async function fetchSchoolId() {
         if (response.ok) {
             const data = await response.json();
             schoolId = data.school_id || data.data?.school_id || data.school?.id || null;
-            console.log('Fetched school ID:', schoolId);
         } else {
             console.warn('Failed to fetch school ID', response.status);
         }
@@ -56,7 +55,6 @@ document.addEventListener('DOMContentLoaded', function () {
 
     const handleSessionChange = function() {
         const sessionId = this.value;
-        console.log('Session selected:', sessionId);
         if (sessionId) {
             loadSessionTermsIntoSelect(sessionId, 'term-id');
         } else {
@@ -173,7 +171,6 @@ document.addEventListener('DOMContentLoaded', function () {
                 medical_information: document.getElementById('medical-info').value
             };
 
-            console.log('Submitting student payload:', payload);
 
             fetch(`${backend_url}/api/v1/students`, {
                 method: 'POST',
@@ -308,19 +305,16 @@ async function loadSessionTermsIntoSelect(sessionId, selectId) {
     }
 
     try {
-        console.log(`Fetching terms for session: ${sessionId}`);
         const url = `${backend_url}/api/v1/sessions/${sessionId}/terms`;
 
         const response = await fetch(url, {
             headers: getHeaders()
         });
 
-        console.log('Terms response status:', response.status);
         if (!select) return;
 
         if (response.ok) {
             const data = await response.json();
-            console.log('Terms response data:', data);
             let terms = [];
             if (Array.isArray(data)) {
                 terms = data;
@@ -332,7 +326,6 @@ async function loadSessionTermsIntoSelect(sessionId, selectId) {
                 terms = data.data.terms;
             }
             select.innerHTML = '<option value="">Please Select Term *</option>';
-            console.log('Loaded terms:', terms);
             if (terms.length > 0) {
                 terms.forEach((term, idx) => {
                     const option = new Option(term.name, term.id);

--- a/update/v14/js/add-student.js
+++ b/update/v14/js/add-student.js
@@ -276,16 +276,33 @@ async function loadSessionTermsIntoSelect(sessionId, selectId) {
 
         if (response.ok) {
             const data = await response.json();
-            console.log('Terms data:', data);
+            console.log('Terms raw data:', data);
 
-            const terms = Array.isArray(data) ? data : data.data || [];
+            let terms = [];
+            if (Array.isArray(data)) {
+                terms = data;
+            } else if (Array.isArray(data.data)) {
+                terms = data.data;
+            } else if (Array.isArray(data.terms)) {
+                terms = data.terms;
+            } else if (Array.isArray(data.data?.terms)) {
+                terms = data.data.terms;
+            } else {
+                console.warn('Unknown terms structure');
+            }
 
             select.innerHTML = '<option value="">Please Select Term *</option>';
-            terms.forEach(term => {
-                const option = new Option(term.name, term.id);
+            if (terms.length > 0) {
+                terms.forEach(term => {
+                    const option = new Option(term.name, term.id);
+                    select.add(option);
+                });
+                console.log(`Loaded ${terms.length} terms into ${selectId}`);
+            } else {
+                const option = new Option('No terms available', '');
                 select.add(option);
-            });
-            console.log(`Loaded ${terms.length} terms into ${selectId}`);
+                console.log('No terms found');
+            }
         } else {
             select.innerHTML = '<option value="">No terms available</option>';
             const errorText = await response.text();


### PR DESCRIPTION
## Summary
- improve loadSessionTermsIntoSelect to show loading state
- support APIs that return terms directly or wrapped in a data object
- provide clearer feedback when terms fail to load

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a656ff2de0832fad38f0a567b44a96